### PR TITLE
Update Python/Django version support

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,7 +1,7 @@
 name: Run pre-commit hooks
 
 env:
-  DEFAULT_PYTHON: 3.9
+  DEFAULT_PYTHON: "3.10"
 
 on:
   push:
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Run tests
 
 env:
-  DEFAULT_PYTHON: 3.9
+  DEFAULT_PYTHON: "3.10"
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,24 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-added-large-files
+  # Run pyupgrade and django-upgrade before ruff, as these two might alter
+  # the code in a way that requires reformatting.
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py310-plus"]
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: "1.29.1"
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "4.2"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.14.2
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
+        args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers=[
     "Environment :: Web Environment",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
@@ -26,11 +25,11 @@ classifiers=[
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
@@ -67,7 +66,7 @@ dependencies = [
     "pre-commit",
 ]
 features = ["all"]
-python = "3.9"
+python = "3.10"
 type = "virtual"
 path = ".venv"
 
@@ -87,16 +86,16 @@ parallel = false
 randomize = true
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.9"]
-django = ["4.2"]
-
-[[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.10", "3.11", "3.12"]
-django = ["4.2", "5.0", "5.1", "5.2"]
+django = ["4.2", "5.1", "5.2"]
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.13"]
 django = ["5.1", "5.2"]
+
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.14"]
+django = ["5.2"]
 
 [tool.hatch.envs.hatch-test.overrides]
 matrix.django.dependencies = [
@@ -120,7 +119,7 @@ DJANGO_SETTINGS_MODULE = "tests.settings"
 pythonpath = "."
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=City-of-Helsinki_django-logger-extra
 sonar.organization=city-of-helsinki
-sonar.python.version=3.9
+sonar.python.version=3.10
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.test.inclusions=**/tests/**/*
 sonar.exclusions=**/tests/**/*,**/migrations/*,commitlint.config.js


### PR DESCRIPTION
- Drop Python 3.9 support
- Add Python 3.14 support
- Drop Django 5.0 support
- Add pyupgrade pre-commit hook
- Add django-upgrade pre-commit hook
- Update ruff pre-commit hook

Refs: RATY-253

BEGIN_COMMIT_OVERRIDE
deps: update python and django version support

Release-As: 1.0.0
END_COMMIT_OVERRIDE