### PR TITLE
fix: default to str in json serialization

### DIFF
--- a/logger_extra/utils.py
+++ b/logger_extra/utils.py
@@ -2,7 +2,6 @@ import logging
 from datetime import date, datetime
 from socket import socket
 from typing import Any
-from uuid import UUID
 
 from django.http import HttpRequest
 
@@ -74,9 +73,5 @@ def json_serialize(input: object):
             "path": input.path,
         }
 
-    if isinstance(input, UUID):
-        return str(input)
-
-    # If you see this TypeError related to object not being serializable,
-    # it means that it should be most likely handled in here.
-    return input
+    # Default to str, should be applicable in most cases.
+    return str(input)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,45 @@
+import datetime
+from socket import socket
+
+import pytest
+from django.test import RequestFactory
+
+from logger_extra.utils import json_serialize
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (datetime.datetime.min, datetime.datetime.min.isoformat()),
+        (datetime.date.min, datetime.date.min.isoformat()),
+        (
+            RequestFactory().get("/foo"),
+            {
+                "source": "http",
+                "method": "GET",
+                "path": "/foo",
+            },
+        ),
+    ],
+)
+def test_json_serialize_handled_cases(value, expected):
+    assert json_serialize(value) == expected
+
+
+def test_json_serialize_socket(monkeypatch):
+    monkeypatch.setattr(socket, "getsockname", lambda *_, **__: "sockname")
+    monkeypatch.setattr(socket, "getpeername", lambda *_, **__: "peername")
+
+    assert json_serialize(socket()) == {
+        "source": "socket",
+        "socket": "sockname",
+        "peer": "peername",
+    }
+
+
+def test_json_serialize_defaults_to_str():
+    class Foo:
+        def __str__(self) -> str:
+            return "hello world"
+
+    assert json_serialize(Foo()) == "hello world"


### PR DESCRIPTION
This fixes a circular reference error if there's an unhandled case.

Refs: RATYK-146