### PR TITLE
feat: add warnings for missing request ids

### DIFF
--- a/logger_extra/apps.py
+++ b/logger_extra/apps.py
@@ -3,7 +3,8 @@ import logging
 from django.apps import AppConfig
 from django.conf import settings
 
-logger = logging.getLogger(__name__)
+LIB_NAME = __package__
+logger = logging.getLogger(LIB_NAME)
 
 
 class LoggerExtraConfig(AppConfig):
@@ -12,10 +13,15 @@ class LoggerExtraConfig(AppConfig):
 
     def ready(self):
         from logger_extra.extras.django_auditlog import enable_django_auditlog_augment
+        from logger_extra.extras.sentry import attach_sentry_handler
 
+        enable_sentry = getattr(settings, "LOGGER_EXTRA_USE_SENTRY", False)
         augment_enabled = getattr(
             settings, "LOGGER_EXTRA_AUGMENT_DJANGO_AUDITLOG", False
         )
+
+        if enable_sentry and not attach_sentry_handler(logger):
+            logger.error("failed to attach sentry handler.")
 
         if augment_enabled and not enable_django_auditlog_augment():
             logger.error("failed to augment django-auditlog.")

--- a/logger_extra/extras/sentry.py
+++ b/logger_extra/extras/sentry.py
@@ -1,0 +1,52 @@
+import logging
+
+try:
+    from sentry_sdk import get_client as get_sentry_client
+    from sentry_sdk.integrations.logging import SentryHandler
+
+    has_sentry = True
+except ImportError:
+    get_sentry_client = None
+    SentryHandler = None
+    has_sentry = False
+
+
+def attach_sentry_handler(logger: logging.Logger) -> bool:
+    if not has_sentry or not get_sentry_client:
+        return False
+
+    try:
+        client = get_sentry_client()
+
+        if not client or not client.is_active():
+            return False
+
+        if any(isinstance(h, SentryHandler) for h in logger.handlers):
+            return True  # Already configured
+
+        sentry_handler = SentryHandler()
+        sentry_handler.setLevel(logging.ERROR)
+
+        logger.addHandler(sentry_handler)
+        return True
+    except Exception:
+        return False
+
+
+def detach_sentry_handler(logger: logging.Logger) -> bool:
+    if not has_sentry:
+        return False
+
+    try:
+        handler = next(
+            (h for h in logger.handlers if isinstance(h, SentryHandler)), None
+        )
+
+        if not handler:
+            return False
+
+        handler.close()
+        logger.removeHandler(handler)
+        return True
+    except Exception:
+        return False

--- a/logger_extra/middleware.py
+++ b/logger_extra/middleware.py
@@ -1,10 +1,13 @@
+import logging
 import uuid
 from collections.abc import Callable
 
 from django.http import HttpRequest, HttpResponse
 
+from logger_extra.apps import LIB_NAME
 from logger_extra.logger_context import logger_context
 
+logger = logging.getLogger(LIB_NAME)
 GetResponseFn = Callable[[HttpRequest], HttpResponse]
 
 
@@ -24,8 +27,20 @@ class RequestIdMiddlewareBase:
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest):
-        # Get request id from source header or generate one here.
-        request_id = request.headers.get(self.request_header, uuid.uuid4())
+        request_id = request.headers.get(self.request_header)
+
+        if not request_id:
+            request_id = str(uuid.uuid4())
+            logger.error(
+                "Request is missing %s header, using generated one instead.",
+                self.request_header,
+                extra={
+                    "path": request.path,
+                    "method": request.method,
+                    "header_name": self.request_header,
+                    "generated_id": request_id,
+                },
+            )
 
         with logger_context({"request_id": request_id}):
             response = self.get_response(request)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ test = [
     "freezegun",
 ]
 auditlog = ["django-auditlog"]
-all = ["django-logger-extra[auditlog]", "django-logger-extra[test]"]
+sentry = ["sentry-sdk"]
+all = ["django-logger-extra[auditlog]", "django-logger-extra[sentry]", "django-logger-extra[test]"]
 
 [project.urls]
 Homepage = "https://github.com/City-of-Helsinki/django-logger-extra"

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -1,10 +1,16 @@
-from unittest import mock
+import logging
+from unittest.mock import MagicMock, patch
 
 import pytest
+from sentry_sdk.integrations.logging import SentryHandler
 
 from logger_extra.extras.django_auditlog import (
     disable_django_auditlog_augment,
     enable_django_auditlog_augment,
+)
+from logger_extra.extras.sentry import (
+    attach_sentry_handler,
+    detach_sentry_handler,
 )
 
 
@@ -15,9 +21,81 @@ def setup_and_teardown():
 
 
 def test_auditlog_present():
-    assert enable_django_auditlog_augment()
+    with patch("logger_extra.extras.django_auditlog.has_auditlog", True):
+        assert enable_django_auditlog_augment()
 
 
-@mock.patch("logger_extra.extras.django_auditlog.has_auditlog", False)
 def test_auditlog_missing():
-    assert not enable_django_auditlog_augment()
+    with patch("logger_extra.extras.django_auditlog.has_auditlog", False):
+        assert not enable_django_auditlog_augment()
+
+
+def test_sentry_present_and_active():
+    logger = logging.getLogger(__name__)
+    mock_client = MagicMock()
+    mock_client.is_active.return_value = True
+
+    with (
+        patch("logger_extra.extras.sentry.get_sentry_client", return_value=mock_client),
+        patch("logger_extra.extras.sentry.has_sentry", True),
+    ):
+        assert attach_sentry_handler(logger)
+        assert attach_sentry_handler(logger)
+
+        num_sentry_handlers = sum(
+            1 for h in logger.handlers if isinstance(h, SentryHandler)
+        )
+
+        assert num_sentry_handlers == 1
+        assert detach_sentry_handler(logger)
+        assert not detach_sentry_handler(logger)
+
+
+def test_sentry_present_and_inactive():
+    logger = logging.getLogger(__name__)
+    mock_client = MagicMock()
+    mock_client.is_active.return_value = False
+
+    with (
+        patch("logger_extra.extras.sentry.has_sentry", True),
+        patch("logger_extra.extras.sentry.get_sentry_client", return_value=mock_client),
+    ):
+        assert not attach_sentry_handler(logger)
+        assert not detach_sentry_handler(logger)
+
+
+def test_sentry_missing():
+    logger = logging.getLogger(__name__)
+
+    with patch("logger_extra.extras.sentry.has_sentry", False):
+        assert not attach_sentry_handler(logger)
+        assert not detach_sentry_handler(logger)
+
+
+def test_sentry_throws_on_attach():
+    logger = logging.getLogger(__name__)
+    mock_client = MagicMock()
+    mock_client.is_active.side_effect = Exception()
+
+    with (
+        patch("logger_extra.extras.sentry.get_sentry_client", return_value=mock_client),
+        patch("logger_extra.extras.sentry.has_sentry", True),
+    ):
+        assert not attach_sentry_handler(logger)
+
+
+def test_sentry_throws_on_detach():
+    handler = SentryHandler()
+
+    logger = MagicMock()
+    logger.handlers = [handler]
+    logger.removeHandler.side_effect = Exception()
+
+    mock_client = MagicMock()
+    mock_client.is_active.return_value = True
+
+    with (
+        patch("logger_extra.extras.sentry.get_sentry_client", return_value=mock_client),
+        patch("logger_extra.extras.sentry.has_sentry", True),
+    ):
+        assert not detach_sentry_handler(logger)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,13 +1,18 @@
 import logging
+from collections.abc import Callable
 
 import pytest
 
+from logger_extra.apps import LIB_NAME
 from logger_extra.filter import LoggerContextFilter
+from tests.views import VIEWS_LOGGER_NAME
+
+DUMMY_LOGGER_NAME = "dummy_middleware"
 
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_dummy_middleware_logger():
-    logger = logging.getLogger("dummy_middleware")
+    logger = logging.getLogger(DUMMY_LOGGER_NAME)
     logger.addFilter(LoggerContextFilter())
     ch = logging.StreamHandler()
     ch.setLevel(logging.INFO)
@@ -16,7 +21,7 @@ def setup_dummy_middleware_logger():
 
 
 def dummy_middleware(get_response):
-    logger = logging.getLogger("dummy_middleware")
+    logger = logging.getLogger(DUMMY_LOGGER_NAME)
 
     def middleware(request):
         logger.info("dummy_middleware says hi")
@@ -24,6 +29,12 @@ def dummy_middleware(get_response):
         return response
 
     return middleware
+
+
+def extract_logger_messages(
+    caplog, predicate: Callable[[logging.LogRecord], bool]
+) -> logging.LogRecord:
+    return [r for r in caplog.records if predicate(r)]
 
 
 def test_add_context_to_middleware_logs(caplog, client, settings):
@@ -34,8 +45,9 @@ def test_add_context_to_middleware_logs(caplog, client, settings):
 
     client.get("/nop")
 
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
+    records = extract_logger_messages(caplog, lambda r: r.name == DUMMY_LOGGER_NAME)
+    assert len(records) == 1
+    record = records[0]
     assert record.name == "dummy_middleware"
     assert record.request_id
 
@@ -43,12 +55,14 @@ def test_add_context_to_middleware_logs(caplog, client, settings):
 def test_generate_request_id_if_not_set(caplog, client, settings):
     settings.MIDDLEWARE = [
         "logger_extra.middleware.XRequestIdMiddleware",
+        "tests.test_middleware.dummy_middleware",
     ]
 
     client.get("/hello")
 
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
+    records = extract_logger_messages(caplog, lambda r: r.name == DUMMY_LOGGER_NAME)
+    assert len(records) == 1
+    record = records[0]
     assert record.request_id
 
 
@@ -59,8 +73,9 @@ def test_use_request_id_from_header(caplog, client, settings):
 
     client.get("/hello", headers={"X-Request-ID": "foo"})
 
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
+    records = extract_logger_messages(caplog, lambda r: r.name == VIEWS_LOGGER_NAME)
+    assert len(records) == 1
+    record = records[0]
     assert record.request_id == "foo"
 
 
@@ -69,11 +84,12 @@ def test_add_logger_context_in_log_record(caplog, client, settings):
         "logger_extra.middleware.XRequestIdMiddleware",
     ]
 
-    client.get("/parrot", {"foo": "bar"})
+    client.get("/parrot", {"foo": "bar"}, headers={"X-Request-ID": "foo"})
 
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
-    assert record.request_id
+    records = extract_logger_messages(caplog, lambda r: r.name == VIEWS_LOGGER_NAME)
+    assert len(records) == 1
+    record = records[0]
+    assert record.request_id == "foo"
     assert record.foo == "bar"
 
 
@@ -84,8 +100,9 @@ def test_logger_context_ignores_builtins(caplog, client, settings):
 
     client.get("/parrot", {"message": "overridden"})
 
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
+    records = extract_logger_messages(caplog, lambda r: r.name == VIEWS_LOGGER_NAME)
+    assert len(records) == 1
+    record = records[0]
     assert record.request_id
     assert record.message != "overridden"
 
@@ -98,6 +115,37 @@ def test_request_id_is_logged_on_error(caplog, client, settings):
     with pytest.raises(ValueError):
         client.get("/error", headers={"X-Request-ID": "foo"})
 
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
+    exceptions = extract_logger_messages(caplog, lambda r: r.exc_info is not None)
+    assert len(exceptions) == 1
+    record = exceptions[0]
     assert record.request_id == "foo"
+
+
+def test_missing_header_triggers_error_log(caplog, client, settings):
+    settings.MIDDLEWARE = [
+        "logger_extra.middleware.XRequestIdMiddleware",
+    ]
+
+    client.get("/hello")
+
+    records = extract_logger_messages(caplog, lambda r: r.name == LIB_NAME)
+    assert len(records) == 1
+
+    record = records[0]
+    assert "missing X-Request-ID header" in record.message
+
+    assert record.header_name == "X-Request-ID"
+    assert record.generated_id is not None
+
+
+def test_response_contains_request_id_header(client, settings):
+    settings.MIDDLEWARE = [
+        "logger_extra.middleware.XRequestIdMiddleware",
+    ]
+
+    response = client.get("/hello", headers={"X-Request-ID": "test-id-123"})
+    assert response["X-Request-ID"] == "test-id-123"
+
+    response = client.get("/hello")
+    assert "X-Request-ID" in response
+    assert len(response["X-Request-ID"]) > 0

--- a/tests/views.py
+++ b/tests/views.py
@@ -4,7 +4,8 @@ from django.http import HttpResponse, JsonResponse
 
 from logger_extra.logger_context import logger_context
 
-logger = logging.getLogger(__name__)
+VIEWS_LOGGER_NAME = "test_views"
+logger = logging.getLogger(VIEWS_LOGGER_NAME)
 
 
 def nop(*_, **__):


### PR DESCRIPTION
Adds validation to request-id middleware. 

If the ID is missing, one will be generated like before but warning will be logged.
If the environment has `LOGGER_EXTRA_USE_SENTRY` variable set to TRUE, it will try to attach sentry handler to library's internal logger and send the warning there as well.